### PR TITLE
video: Add workaround to prevent usage of MMX intrinsics

### DIFF
--- a/src/video/SDL_blit_A.c
+++ b/src/video/SDL_blit_A.c
@@ -23,6 +23,11 @@
 #include "SDL_video.h"
 #include "SDL_blit.h"
 
+/* Workaround for lack of MMX intrinsic support for non-SSE2 targets */
+#ifdef __clang__
+#undef __MMX__
+#endif
+
 /* Functions to perform alpha blended blitting */
 
 /* N->1 blending with per-surface alpha */


### PR DESCRIPTION
Supersedes https://github.com/XboxDev/nxdk/pull/734

Instead of undefining `__MMX__` everywhere we just undefine it in the blitting code, preventing the usage of MMX intrinsics and dependency on SSE2 as of clang/LLVM 20