### PR TITLE
sdl: Fix for SDL_XBOX_JoystickGetDeviceName()

### DIFF
--- a/src/joystick/xbox/SDL_xboxjoystick.c
+++ b/src/joystick/xbox/SDL_xboxjoystick.c
@@ -91,6 +91,8 @@ typedef struct joystick_hwdata
 
 static Sint32 parse_input_data(xid_dev_t *xid_dev, PXINPUT_GAMEPAD controller, Uint8 *rdata);
 
+static Sint32 SDL_XBOX_JoystickGetDevicePlayerIndex(Sint32 device_index);
+
 //Create SDL events for connection/disconnection. These events can then be handled in the user application
 static void connection_callback(xid_dev_t *xid_dev, int status) {
     JOY_DBGMSG("connection_callback: uid %i connected \n", xid_dev->uid);
@@ -228,18 +230,17 @@ static const char* SDL_XBOX_JoystickGetDeviceName(Sint32 device_index) {
     static char name[MAX_JOYSTICKS][64];
     Uint32 max_len = sizeof(name[device_index]);
 
-    //FIXME. See SDL_XBOX_JoystickGetDevicePlayerIndex().
-    Sint32 player_index = device_index;
+    Sint32 player_index = SDL_XBOX_JoystickGetDevicePlayerIndex(device_index);
     switch (xid_dev->xid_desc.bType)
     {
     case XID_TYPE_GAMECONTROLLER:
-        SDL_snprintf(name[device_index], max_len, "Original Xbox Controller #%u", player_index + 1);
+        SDL_snprintf(name[device_index], max_len, "Original Xbox Controller #%u", player_index);
         break;
     case XID_TYPE_XREMOTE:
-        SDL_snprintf(name[device_index], max_len, "Original Xbox IR Remote #%u", player_index + 1);
+        SDL_snprintf(name[device_index], max_len, "Original Xbox IR Remote #%u", player_index);
         break;
     case XID_TYPE_STEELBATTALION:
-        SDL_snprintf(name[device_index], max_len, "Steel Battalion Controller #%u", player_index + 1);
+        SDL_snprintf(name[device_index], max_len, "Steel Battalion Controller #%u", player_index);
         break;
 
     }

--- a/src/joystick/xbox/SDL_xboxjoystick.c
+++ b/src/joystick/xbox/SDL_xboxjoystick.c
@@ -36,6 +36,8 @@
 #include <assert.h>
 #include <usbh_lib.h>
 #include <xid_driver.h>
+#include <usb/libusbohci/inc/hub.h>
+#include <xboxkrnl/xboxkrnl.h>
 
 //#define SDL_JOYSTICK_XBOX_DEBUG
 #ifdef SDL_JOYSTICK_XBOX_DEBUG
@@ -146,6 +148,34 @@ static xid_dev_t *xid_from_device_index(Sint32 device_index) {
     return NULL;
 }
 
+static Sint32 xid_get_device_port(xid_dev_t *xid_dev) {
+    UDEV_T *udev, *parent_udev;
+    
+    udev = xid_dev->iface->udev;
+    ULONG has_internal_hub = XboxHardwareInfo.Flags & XBOX_HW_FLAG_INTERNAL_USB_HUB;
+    while (udev != NULL)
+    {
+        parent_udev = NULL;
+        if (udev->parent != NULL) {
+            parent_udev = udev->parent->iface->udev;
+        }
+
+        if ((has_internal_hub && parent_udev->parent == NULL) || (!has_internal_hub && udev->parent == NULL))
+        {
+            switch (udev->port_num)
+            {
+                case 3: return 1;
+                case 4: return 2;
+                case 1: return 3;
+                case 2: return 4;
+                default: return 0;
+            }
+        }
+        udev = parent_udev;
+    }
+    return 0;
+}
+
 static SDL_bool core_has_init = SDL_FALSE;
 static Sint32 SDL_XBOX_JoystickInit(void) {
     if (!core_has_init)
@@ -217,17 +247,18 @@ static const char* SDL_XBOX_JoystickGetDeviceName(Sint32 device_index) {
     return name[device_index];
 }
 
-//FIXME
-//Player index is just the order the controllers were plugged in.
-//This may not be what the user expects on a Xbox console.
-//Player index should consider that Port 1 = player 1, Port 2 = player 2 etc.
+// Returns the port number the device is connected to
+// 1 = Port 1, 2 = Port 2, etc.
 static Sint32 SDL_XBOX_JoystickGetDevicePlayerIndex(Sint32 device_index) {
     xid_dev_t *xid_dev = xid_from_device_index(device_index);
 
     if (xid_dev == NULL)
         return -1;
 
-    Sint32 player_index = device_index;
+    Sint32 player_index = xid_get_device_port(xid_dev);
+    if (player_index == 0) {    // fallback to device_index if xid_get_device_port fails (returns 0)
+        player_index = device_index;
+    }
     JOY_DBGMSG("SDL_XBOX_JoystickGetDevicePlayerIndex: %i\n", player_index);
 
     return player_index;


### PR DESCRIPTION
Provided a fix for the `SDL_XBOX_JoystickGetDeviceName` function using the now fixed `SDL_XBOX_JoystickGetDevicePlayerIndex` function.