### PR TITLE
Added standard logging for Xbox

### DIFF
--- a/src/SDL_log.c
+++ b/src/SDL_log.c
@@ -428,9 +428,14 @@ SDL_LogOutput(void *userdata, int category, SDL_LogPriority priority,
     }
 #elif defined(NXDK)
     {
-        static char text[SDL_MAX_LOG_MESSAGE];
-        SDL_snprintf(text, SDL_MAX_LOG_MESSAGE, "%s: %s\n", SDL_priority_prefixes[priority], message);
-        OutputDebugStringA(text);
+        // Calculate length of both strings + Colon, space, new-line, null-terminator.
+        size_t length = strlen(SDL_priority_prefixes[priority]) + strlen(message) + 4;
+        char * text = SDL_stack_alloc(char, length);
+        if (text) {
+            SDL_snprintf(text, length, "%s: %s\n", SDL_priority_prefixes[priority], message);
+            OutputDebugStringA(text);
+            SDL_stack_free(text);
+        }
     }
 #endif
 #if HAVE_STDIO_H

--- a/src/SDL_log.c
+++ b/src/SDL_log.c
@@ -37,6 +37,10 @@
 #include <android/log.h>
 #endif
 
+#if defined(NXDK)
+#include <windows.h>
+#endif
+
 #define DEFAULT_PRIORITY                SDL_LOG_PRIORITY_CRITICAL
 #define DEFAULT_ASSERT_PRIORITY         SDL_LOG_PRIORITY_WARN
 #define DEFAULT_APPLICATION_PRIORITY    SDL_LOG_PRIORITY_INFO
@@ -421,6 +425,12 @@ SDL_LogOutput(void *userdata, int category, SDL_LogPriority priority,
         pFile = fopen ("SDL_Log.txt", "a");
         fprintf(pFile, "%s: %s\n", SDL_priority_prefixes[priority], message);
         fclose (pFile);
+    }
+#elif defined(NXDK)
+    {
+        static char text[SDL_MAX_LOG_MESSAGE];
+        SDL_snprintf(text, SDL_MAX_LOG_MESSAGE, "%s: %s\n", SDL_priority_prefixes[priority], message);
+        OutputDebugStringA(text);
     }
 #endif
 #if HAVE_STDIO_H


### PR DESCRIPTION
Pipe all `SDL_Log()` commands to `OutputDebugStringA()` by default so that users can take advantage of SDL for all their logging needs.